### PR TITLE
fix for movies not played as 'mediatype': 'movie'

### DIFF
--- a/plugin.video.realizer/resources/lib/modules/player.py
+++ b/plugin.video.realizer/resources/lib/modules/player.py
@@ -112,6 +112,19 @@ class player(xbmc.Player):
             if self.content == 'episode': item.setArt({'icon': thumb, 'thumb': fanart, 'poster': poster, 'fanart':fanart, 'tvshow.poster': poster, 'season.poster': thumb , 'tvshow.landscape':thumb})
             else: item.setArt({'icon': thumb, 'thumb': thumb, 'poster': thumb, 'fanart':thumb})
 
+#fix where movies played from openmeta have infoMeta set to FALSE
+            if 'movie' in str(meta):
+                infoMeta = True
+
+#Send additional meta data which shows up on OSD when mediatype = movie
+            if self.content == 'movie' and infoMeta == True:
+                self.infolabels.update({"mediatype": "movie", "premiered": meta['premiered'],  "Title": meta['title'], "genre": meta['genre'], "rating": meta['rating'], "mpaa": meta['mpaa']})
+                try:
+                    item.setArt({'icon': thumb, 'thumb': fanart, 'poster': poster, 'fanart':fanart})
+                    item.setArt({'clearart': clearart})
+                except:
+                    pass
+
             item.setInfo(type='Video', infoLabels = self.infolabels)
 
             control.player.play(url, item)


### PR DESCRIPTION
In player.py Movies played from openmeta sent with correct metadata do not get played as "mediatype = movie" because "infoMeta" is set to false. I couldn't figure out why this was happening but adding a test for "if 'movie' in str(meta):" to set "infoMeta = True" seems to fix this. You can then pass metadata which will be displayed on the OSD.

This may also effect episodes played via openmeta through lists, ie anything which gets routed directly to player.py rather than being picked up via tvshows.py/episodes.py/movies.py??