### PR TITLE
Adapt Skip TV Intro for Kodi v20

### DIFF
--- a/script.tvskipintro/addon.xml
+++ b/script.tvskipintro/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tvskipintro" version="2021.12.03" name="TV Skip Intro" provider-name="zDuts but all credit to aenema">
+<addon id="script.tvskipintro" version="2022.02.28" name="TV Skip Intro" provider-name="zDuts but all credit to aenema">
 	<requires>
 		<import addon="xbmc.python" version="3.00.0" />
 	</requires>

--- a/script.tvskipintro/service.py
+++ b/script.tvskipintro/service.py
@@ -23,8 +23,8 @@ import xbmcvfs,xbmc,xbmcaddon,json,os,xbmcgui, time, re
 KODI_VERSION = int(xbmc.getInfoLabel("System.BuildVersion").split(".")[0])
 addonInfo = xbmcaddon.Addon().getAddonInfo
 settings = xbmcaddon.Addon().getSetting
-profilePath = xbmc.translatePath(addonInfo('profile'))
-addonPath = xbmc.translatePath(addonInfo('path'))
+profilePath = xbmcvfs.translatePath(addonInfo('profile'))
+addonPath = xbmcvfs.translatePath(addonInfo('path'))
 skipFile = os.path.join(profilePath, 'skipintro.json')
 defaultSkip = settings('default.skip')
 if not os.path.exists(profilePath): xbmcvfs.mkdir(profilePath)


### PR DESCRIPTION
Hi,
I noticed that the TV Skip Intro addon wasn't working for Kodi v20, because of changes in the API. I saw that someone already created a pull request for other add-ons in this repository, so I thought I will do the same for TV Skip Intro, because it is one that I use regulary.

Hopefully this can be merged soon.

If there are any questions or change requests, please let me know.

I tested everything locally and it works the same way it did before.

Thank you.